### PR TITLE
Feature/include badges

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -36,6 +36,7 @@ jobs:
           echo "pylint_score=$pylint_score" >> $GITHUB_OUTPUT
       - name: Generate pylint badge
         run: |
+          echo $pylint_score
           pip install anybadge
           anybadge -l pylint -v $pylint_score -f pylint.svg 2=red 4=orange 8=yellow 10=green
         env:

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -39,19 +39,19 @@ jobs:
         run: |
           echo "The pylint value equals ${{ steps.pylint_calc.outputs.pylint_score }}"
           pip install anybadge
-          anybadge -l pylint -v ${{ steps.pylint_calc.outputs.pylint_score }} -f out/pylint.svg 2=red 4=orange 8=yellow 10=green
+          anybadge -l pylint -v ${{ steps.pylint_calc.outputs.pylint_score }} -f pylint.svg 2=red 4=orange 8=yellow 10=green
       - name: Store pylint badge as artifact
         uses: actions/upload-artifact@v4
         with:
           name: pylint_badge
-          path: out/pylint.svg
+          path: pylint.svg
           compression-level: 0 # no compression
           overwrite: true
       - name: Commit pylint badge to repository
         run:
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          mv pylint_badge.svg badges/pylint_badge.svg
+          mv pylint.svg badges/pylint_badge.svg
           git add badges/pylint_badge.svg
           git commit -m "Update pylint badge"
           git push

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -47,10 +47,15 @@ jobs:
           path: pylint.svg
           compression-level: 0 # no compression
           overwrite: true
+      
+      - name: Checkout original repository
+        uses: actions/checkout@v3
+        
       - name: Commit pylint badge to repository
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
+          mkdir -p badges
           mv pylint.svg badges/pylint_badge.svg
           git add badges/pylint_badge.svg
           git commit -m "Update pylint badge"

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Generate pylint badge
         run: |
           pip install anybadge
-          anybadge -l pylint -v ${steps.pylint.outputs.pylint_score} -f pylint.svg 2=red 4=orange 8=yellow 10=green
+          anybadge -l pylint -v ${{ steps.pylint.outputs.pylint_score }} -f pylint.svg 2=red 4=orange 8=yellow 10=green
       - name: Store pylint badge as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -81,4 +81,4 @@ jobs:
 
       - name: Run flake8 on src/
         run: |
-          poetry run flake8 src/
+          poetry run flake8 src/ --verbose

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -61,7 +61,7 @@ jobs:
           mv pylint.svg badges/pylint_badge.svg
           git add badges/pylint_badge.svg
           git commit -m "Update pylint badge"
-          git push
+          git push || true  # adding true statement to avoid error on "nothing to commit"
 
   flake8:
     name: Flake8 Check

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Run flake8 on src/ and store pass/fail status
         run: |
-          if poetry run flake8 src/ --verbose; then flake="passing" else flake="failing" fi
+          if poetry run flake8 src/ --verbose; then flake="passing"; else flake="failing"; fi
           echo "flake=$flake" >> $GITHUB_OUTPUT
         id: flake_calc
       - name: Generate flake badge

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -2,7 +2,7 @@ name: Code Quality
 
 on:
   push:
-    branches: [main]
+    branches: [main, feature/include-badges]
   pull_request:
     branches: [main]
 
@@ -30,9 +30,21 @@ jobs:
           poetry install
           poetry run pip install -e ./lib-ml
 
-      - name: Run pylint on src/
+      - name: Run pylint on src/ and store output
         run: |
-          PYTHONPATH=. poetry run pylint src/
+          pylint_score=$(PYTHONPATH=. poetry run pylint src/ | tr / " " | grep "Your code has been rated at" | awk "{print $7}")
+          echo "pylint_score=$pylint_score" >> $GITHUB_OUTPUT
+      - name: Generate pylint badge
+        run: |
+          pip install anybadge
+          anybadge -l pylint -v $pylint_score pylint.svg 2=red 4=orange 8=yellow 10=green
+        env:
+          pylint_score: ${{ needs.pylint.outputs.pylint_score }}
+      - name: Store pylint badge as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pylint_badge.svg
+          path: pylint.svg
 
   flake8:
     name: Flake8 Check

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -86,7 +86,7 @@ jobs:
         id: flake_calc
       - name: Generate flake badge
         run: |
-          echo "The flake8 status equals ${{ steps.flake_calc.outputs.pylint_score }}"
+          echo "The flake8 status equals ${{ steps.flake_calc.outputs.flake }}"
           pip install anybadge
           anybadge -l flake8 -v ${{ steps.flake_calc.outputs.flake }} -f flake.svg passing=green failing=red
       - name: Store flake8 badge as artifact

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -36,11 +36,8 @@ jobs:
           echo "pylint_score=$pylint_score" >> $GITHUB_OUTPUT
       - name: Generate pylint badge
         run: |
-          echo $pylint_score
           pip install anybadge
-          anybadge -l pylint -v $pylint_score -f pylint.svg 2=red 4=orange 8=yellow 10=green
-        env:
-          pylint_score: ${{ needs.pylint.outputs.pylint_score }}
+          anybadge -l pylint -v ${steps.pylint.outputs.pylint_score} -f pylint.svg 2=red 4=orange 8=yellow 10=green
       - name: Store pylint badge as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run pylint on src/ and store output
         run: |
-          pylint_score=$(PYTHONPATH=. poetry run pylint src/ | tr / " " | grep "Your code has been rated at" | awk "{print $7}")
+          pylint_score=$(PYTHONPATH=. poetry run pylint src/ | tr / " " | grep "Your code has been rated at" | awk '{print $7}')
           echo "pylint_score=$pylint_score" >> $GITHUB_OUTPUT
         id: pylint_calc
       - name: Generate pylint badge

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -48,7 +48,7 @@ jobs:
           compression-level: 0 # no compression
           overwrite: true
       - name: Commit pylint badge to repository
-        run:
+        run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
           mv pylint.svg badges/pylint_badge.svg

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -79,6 +79,35 @@ jobs:
         run: |
           poetry install
 
-      - name: Run flake8 on src/
+      - name: Run flake8 on src/ and store pass/fail status
         run: |
-          poetry run flake8 src/ --verbose
+          if poetry run flake8 src/ --verbose; then flake="passing" else flake="failing" fi
+          echo "flake=$flake" >> $GITHUB_OUTPUT
+        id: flake_calc
+      - name: Generate flake badge
+        run: |
+          echo "The flake8 status equals ${{ steps.flake_calc.outputs.pylint_score }}"
+          pip install anybadge
+          anybadge -l flake8 -v ${{ steps.flake_calc.outputs.flake }} -f flake.svg passing=green failing=red
+      - name: Store flake8 badge as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: flake_badge
+          path: flake.svg
+          compression-level: 0 # no compression
+          overwrite: true
+      
+      - name: Checkout original repository
+        uses: actions/checkout@v3
+        with:
+          clean: false
+        
+      - name: Commit pylint badge to repository
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          mkdir -p badges
+          mv flake.svg badges/flake_badge.svg
+          git add badges/flake_badge.svg
+          git commit -m "Update flake badge" || true # see below
+          git push || true  # adding true statement to avoid error on "nothing to commit"

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           name: pylint_badge.svg
           path: pylint.svg
+          compression-level: 0 # no compression
 
   flake8:
     name: Flake8 Check

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -39,14 +39,22 @@ jobs:
         run: |
           echo "The pylint value equals ${{ steps.pylint_calc.outputs.pylint_score }}"
           pip install anybadge
-          anybadge -l pylint -v ${{ steps.pylint_calc.outputs.pylint_score }} -f pylint.svg 2=red 4=orange 8=yellow 10=green
+          anybadge -l pylint -v ${{ steps.pylint_calc.outputs.pylint_score }} -f out/pylint.svg 2=red 4=orange 8=yellow 10=green
       - name: Store pylint badge as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: pylint_badge.svg
-          path: pylint.svg
+          name: pylint_badge
+          path: out/pylint.svg
           compression-level: 0 # no compression
           overwrite: true
+      - name: Commit pylint badge to repository
+        run:
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          mv pylint_badge.svg badges/pylint_badge.svg
+          git add badges/pylint_badge.svg
+          git commit -m "Update pylint badge"
+          git push
 
   flake8:
     name: Flake8 Check

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Generate pylint badge
         run: |
           pip install anybadge
-          anybadge -l pylint -v $pylint_score pylint.svg 2=red 4=orange 8=yellow 10=green
+          anybadge -l pylint -v $pylint_score -f pylint.svg 2=red 4=orange 8=yellow 10=green
         env:
           pylint_score: ${{ needs.pylint.outputs.pylint_score }}
       - name: Store pylint badge as artifact

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -50,6 +50,8 @@ jobs:
       
       - name: Checkout original repository
         uses: actions/checkout@v3
+        with:
+          clean: false
         
       - name: Commit pylint badge to repository
         run: |

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -34,11 +34,12 @@ jobs:
         run: |
           pylint_score=$(PYTHONPATH=. poetry run pylint src/ | tr / " " | grep "Your code has been rated at" | awk "{print $7}")
           echo "pylint_score=$pylint_score" >> $GITHUB_OUTPUT
+        id: pylint_calc
       - name: Generate pylint badge
         run: |
-          echo "The pylint value equals ${{ steps.pylint.outputs.pylint_score }}"
+          echo "The pylint value equals ${{ steps.pylint_calc.outputs.pylint_score }}"
           pip install anybadge
-          anybadge -l pylint -v ${{ steps.pylint.outputs.pylint_score }} -f pylint.svg 2=red 4=orange 8=yellow 10=green
+          anybadge -l pylint -v ${{ steps.pylint_calc.outputs.pylint_score }} -f pylint.svg 2=red 4=orange 8=yellow 10=green
       - name: Store pylint badge as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -46,6 +46,7 @@ jobs:
           name: pylint_badge.svg
           path: pylint.svg
           compression-level: 0 # no compression
+          overwrite: true
 
   flake8:
     name: Flake8 Check

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -36,6 +36,7 @@ jobs:
           echo "pylint_score=$pylint_score" >> $GITHUB_OUTPUT
       - name: Generate pylint badge
         run: |
+          echo "The pylint value equals ${{ steps.pylint.outputs.pylint_score }}"
           pip install anybadge
           anybadge -l pylint -v ${{ steps.pylint.outputs.pylint_score }} -f pylint.svg 2=red 4=orange 8=yellow 10=green
       - name: Store pylint badge as artifact

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -60,7 +60,7 @@ jobs:
           mkdir -p badges
           mv pylint.svg badges/pylint_badge.svg
           git add badges/pylint_badge.svg
-          git commit -m "Update pylint badge"
+          git commit -m "Update pylint badge" || true # see below
           git push || true  # adding true statement to avoid error on "nothing to commit"
 
   flake8:

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -2,7 +2,7 @@ name: Code Quality
 
 on:
   push:
-    branches: [main, feature/include-badges]
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Code Quality](https://github.com/remla25-team20/model-training/actions/workflows/CodeQuality.yml/badge.svg)](https://github.com/remla25-team20/model-training/actions/workflows/CodeQuality.yml)
-
+[![PyLint](/badges/pylint_badge.svg)](https://github.com/remla25-team20/model-training/actions/workflows/CodeQuality.yml)
 
 # model-training
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Code Quality](https://github.com/remla25-team20/model-training/actions/workflows/CodeQuality.yml/badge.svg)](https://github.com/remla25-team20/model-training/actions/workflows/CodeQuality.yml)
 [![PyLint](/badges/pylint_badge.svg)](https://github.com/remla25-team20/model-training/actions/workflows/CodeQuality.yml)
-
+[![Flake8](/badges/flake_badge.svg)](https://github.com/remla25-team20/model-training/actions/workflows/CodeQuality.yml)
 # model-training
 
 This repository contains the training pipeline for a sentiment analysis model built for restaurant reviews, used as part of the Release Engineering course.

--- a/badges/flake_badge.svg
+++ b/badges/flake_badge.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="103" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="anybadge_1">
+        <rect width="103" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#anybadge_1)">
+        <path fill="#555" d="M0 0h47v20H0z"/>
+        <path fill="#4C1" d="M47 0h56v20H47z"/>
+        <path fill="url(#b)" d="M0 0h103v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="24.5" y="15" fill="#010101" fill-opacity=".3">flake8</text>
+        <text x="23.5" y="14">flake8</text>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="76.0" y="15" fill="#010101" fill-opacity=".3">passing</text>
+        <text x="75.0" y="14">passing</text>
+    </g>
+</svg>

--- a/badges/pylint_badge.svg
+++ b/badges/pylint_badge.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="anybadge_1">
+        <rect width="80" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#anybadge_1)">
+        <path fill="#555" d="M0 0h44v20H0z"/>
+        <path fill="#4c1" d="M44 0h36v20H44z"/>
+        <path fill="url(#b)" d="M0 0h80v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="23.0" y="15" fill="#010101" fill-opacity=".3">pylint</text>
+        <text x="22.0" y="14">pylint</text>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="63.0" y="15" fill="#010101" fill-opacity=".3">10.0</text>
+        <text x="62.0" y="14">10.0</text>
+    </g>
+</svg>


### PR DESCRIPTION
Included the generation of a pylint score badge and a flake8 passing / failing badge.

Upon running of the workflow, badges are generated from the test results. README.md correctly refers to these files on the repository.

Currently configured to only trigger on `main` branch.