### PR TITLE
changed trigger condition to be on every push

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -1,10 +1,6 @@
 name: Code Quality
 
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+on: push
 
 jobs:
   pylint:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,8 +1,6 @@
 name: 'coverage'
-on:
-  push:
-    branches:
-      - '*'
+on: push
+
 jobs:
   coverage:
     permissions:


### PR DESCRIPTION
Trivial change setting the `on:` parameter to `push` in the github workflows for `CodeQuality.yml` and `coverage.yml`.

This achieves compliance with the "on _every_ push" requirement for assignment 4 tests.